### PR TITLE
fix(PeriphDrivers): Rename SPI1 to SPIMSS DMA request select to be consistent with user guide

### DIFF
--- a/Libraries/PeriphDrivers/Include/MAX32660/dma.h
+++ b/Libraries/PeriphDrivers/Include/MAX32660/dma.h
@@ -61,19 +61,23 @@ typedef enum {
     MXC_DMA_REQUEST_MEMTOMEM =
         MXC_S_DMA_CFG_REQSEL_MEMTOMEM, ///< Memory to Memory DMA Request Selection
     MXC_DMA_REQUEST_SPI0RX = MXC_S_DMA_CFG_REQSEL_SPI0RX, ///< SPI0 Receive DMA Request Selection
-    MXC_DMA_REQUEST_SPI1RX = MXC_S_DMA_CFG_REQSEL_SPI1RX, ///< SPI1 Receive DMA Request Selection
+    MXC_DMA_REQUEST_SPIMSSRX = MXC_S_DMA_CFG_REQSEL_SPI1RX, ///< SPIMSS Receive DMA Request Selection
     MXC_DMA_REQUEST_UART0RX = MXC_S_DMA_CFG_REQSEL_UART0RX, ///< UART0 Receive DMA Request Selection
     MXC_DMA_REQUEST_UART1RX = MXC_S_DMA_CFG_REQSEL_UART1RX, ///< UART1 Receive DMA Request Selection
     MXC_DMA_REQUEST_I2C0RX = MXC_S_DMA_CFG_REQSEL_I2C0RX, ///< I2C0 Receive DMA Request Selection
     MXC_DMA_REQUEST_I2C1RX = MXC_S_DMA_CFG_REQSEL_I2C1RX, ///< I2C1 Receive DMA Request Selection
     MXC_DMA_REQUEST_SPI0TX = MXC_S_DMA_CFG_REQSEL_SPI0TX, ///< SPI0 Transmit DMA Request Selection
-    MXC_DMA_REQUEST_SPI1TX = MXC_S_DMA_CFG_REQSEL_SPI1TX, ///< SPI1 Transmit DMA Request Selection
+    MXC_DMA_REQUEST_SPIMSSTX = MXC_S_DMA_CFG_REQSEL_SPI1TX, ///< SPIMSS Transmit DMA Request Selection
     MXC_DMA_REQUEST_UART0TX =
         MXC_S_DMA_CFG_REQSEL_UART0TX, ///< UART0 Transmit DMA Request Selection
     MXC_DMA_REQUEST_UART1TX =
         MXC_S_DMA_CFG_REQSEL_UART1TX, ///< UART1 Transmit DMA Request Selection
     MXC_DMA_REQUEST_I2C0TX = MXC_S_DMA_CFG_REQSEL_I2C0TX, ///< I2C0 Transmit DMA Request Selection
     MXC_DMA_REQUEST_I2C1TX = MXC_S_DMA_CFG_REQSEL_I2C1TX, ///< I2C1 Transmit DMA Request Selection
+
+    // Deprecated names
+    MXC_DMA_REQUEST_SPI1RX = MXC_S_DMA_CFG_REQSEL_SPI1RX, ///< SPI1 Receive DMA Request Selection
+    MXC_DMA_REQUEST_SPI1TX = MXC_S_DMA_CFG_REQSEL_SPI1TX, ///< SPI1 Transmit DMA Request Selection
 } mxc_dma_reqsel_t;
 
 /** @brief Enumeration for the DMA prescaler */

--- a/Libraries/PeriphDrivers/Source/SPI/spi_me11.c
+++ b/Libraries/PeriphDrivers/Source/SPI/spi_me11.c
@@ -256,7 +256,7 @@ int MXC_SPI_MasterTransactionDMA(mxc_spi_req_t *req)
             break;
 
         case 1:
-            reqselTx = MXC_DMA_REQUEST_SPI1TX;
+            reqselTx = MXC_DMA_REQUEST_SPIMSSTX;
             break;
 
         default:
@@ -271,7 +271,7 @@ int MXC_SPI_MasterTransactionDMA(mxc_spi_req_t *req)
             break;
 
         case 1:
-            reqselTx = MXC_DMA_REQUEST_SPI1RX;
+            reqselTx = MXC_DMA_REQUEST_SPIMSSRX;
             break;
 
         default:
@@ -310,7 +310,7 @@ int MXC_SPI_SlaveTransactionDMA(mxc_spi_req_t *req)
             break;
 
         case 1:
-            reqselTx = MXC_DMA_REQUEST_SPI1TX;
+            reqselTx = MXC_DMA_REQUEST_SPIMSSTX;
             break;
 
         default:
@@ -325,7 +325,7 @@ int MXC_SPI_SlaveTransactionDMA(mxc_spi_req_t *req)
             break;
 
         case 1:
-            reqselRx = MXC_DMA_REQUEST_SPI1RX;
+            reqselRx = MXC_DMA_REQUEST_SPIMSSRX;
             break;
 
         default:


### PR DESCRIPTION
### Description

Due to PRs across forks, the change you haven't merged from main yet is also included in this PR.

The specific change I want to make in this PR is adding the SPIMSS request select name and deprecating (but still left in for backward compatibility) the SPI1 request select value.

### Checklist Before Requesting Review

- [ ] PR Title follows correct guidelines.
- [ ] Description of changes and all other relevant information.
- [ ] (Optional) Link any related GitHub issues [using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] (Optional) Provide info on any relevant functional testing/validation.  For API changes or significant features, this is not optional.